### PR TITLE
🐛 fix path resolve

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,7 @@ import { clamp } from "@hyoretsu/utils";
 import express, { Router } from "express";
 import { existsSync, readFileSync } from "fs";
 import handlebars from "handlebars";
+import path from "path";
 import { version } from "../package.json";
 import { getName } from "./helpers/getName";
 import { getNum } from "./helpers/getNum";
@@ -104,7 +105,7 @@ routes.get("/", (req, res) => {
 	res.redirect(`${subpath}/configure`);
 });
 
-const { dirname } = import.meta;
+const dirname = path.join(process.cwd(), process.env.NODE_ENV === "production" ? "dist" : "src");
 
 routes.use("/", express.static(`${dirname}/frontend`));
 


### PR DESCRIPTION
Un correctif pour ce bug : 
```js
Server is running at http://localhost:3000
node:fs:596
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open 'undefined/frontend/configure/index.hbs'
    at Object.openSync (node:fs:596:3)
    at readFileSync (node:fs:464:35)
    [....]```
    
    
 à cause de cette ligne : 
 `route.js`
 ```js
 const { dirname } = import.meta;
 ```
 
 `dirname` ne prends pas en compte le dossier `src` ou `dist`
 
 fix : 
 ```js
 const dirname = path.join(process.cwd(), process.env.NODE_ENV === "production" ? "dist" : "src");
```
    