### PR TITLE
Add more spacing when displaying the metadata in stremio

### DIFF
--- a/utils/process_results.py
+++ b/utils/process_results.py
@@ -47,7 +47,7 @@ def process_stream(stream, cached, stream_type, season, episode, config):
 
     return {
         "name": name,
-        "title": f"{stream['title']}\r\n{get_emoji(stream['language'])}👥{stream['seeders']}📂"
+        "title": f"{stream['title']}\r\n{get_emoji(stream['language'])}   👥 {stream['seeders']}   📂 "
                  f"{round(int(stream['size']) / 1024 / 1024 / 1024, 2)}GB",
         "url": f"{config['addonHost']}/{base64.b64encode(json.dumps(config).encode('utf-8')).decode('utf-8')}/playback/"
                f"{base64.b64encode(json.dumps(query).encode('utf-8')).decode('utf-8')}/{stream['title'].replace(' ', '.')}"


### PR DESCRIPTION
Very small pr, but i think it looks much nicer.

Before:
![image](https://github.com/aymene69/stremio-jackett/assets/69892203/509148d0-f36d-4416-98a8-0941835ef28d)

After:
![image](https://github.com/aymene69/stremio-jackett/assets/69892203/2fd4087d-2a1e-4ab5-a4a1-2178137c0baa)
