### PR TITLE
Add support for Brazilian Portuguese

### DIFF
--- a/source/jackett/jackett_service.py
+++ b/source/jackett/jackett_service.py
@@ -211,7 +211,10 @@ class JackettService:
             indexer.id = item.attrib['id']
             indexer.link = item.find('link').text
             indexer.type = item.find('type').text
-            indexer.language = item.find('language').text.split('-')[0]
+            if item.find('language').text.split('-')[0] in ['en', 'fr', 'es', 'de', 'it', 'ru', 'nl', 'hu', 'la']:
+                indexer.language = item.find('language').text.split('-')[0]
+            else:
+                indexer.language = item.find('language').text # Add support for localizations (e.g., pt-BR)
 
             self.logger.info(f"Indexer: {indexer.title} - {indexer.link} - {indexer.type}")
 

--- a/source/jackett/jackett_service.py
+++ b/source/jackett/jackett_service.py
@@ -211,10 +211,10 @@ class JackettService:
             indexer.id = item.attrib['id']
             indexer.link = item.find('link').text
             indexer.type = item.find('type').text
-            if item.find('language').text.split('-')[0] in ['en', 'fr', 'es', 'de', 'it', 'ru', 'nl', 'hu', 'la']:
-                indexer.language = item.find('language').text.split('-')[0]
-            else:
+            if item.find('language').text.split('-')[0] in ['pt']:
                 indexer.language = item.find('language').text # Add support for localizations (e.g., pt-BR)
+            else:
+                indexer.language = item.find('language').text.split('-')[0]
 
             self.logger.info(f"Indexer: {indexer.title} - {indexer.link} - {indexer.type}")
 

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -409,8 +409,8 @@
                                     <input type="checkbox" id="pt"/>
                                     🇵🇹 <span class="ml-1">Portuguese</span>
                                 </label>
-                                <label for="pt-br">
-                                    <input type="checkbox" id="pt-br"/>
+                                <label for="pt-BR">
+                                    <input type="checkbox" id="pt-BR"/>
                                     🇧🇷 <span class="ml-1">Brazilian Portuguese</span>
                                 </label>
                                 <label for="ru">

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -409,6 +409,10 @@
                                     <input type="checkbox" id="pt"/>
                                     🇵🇹 <span class="ml-1">Portuguese</span>
                                 </label>
+                                <label for="pt-br">
+                                    <input type="checkbox" id="pt-br"/>
+                                    🇧🇷 <span class="ml-1">Brazilian Portuguese</span>
+                                </label>
                                 <label for="ru">
                                     <input type="checkbox" id="ru"/>
                                     🇷🇺 <span class="ml-1">Russian</span>


### PR DESCRIPTION
Most titles in Brazilian Portuguese are different to European Portuguese. That makes translated search (using TMDB metadata) useless for Jackett's Brazilian Portuguese indexers
To list a few titles:

- Terminator
  - pt-PT: O Exterminador Implacável
  - pt-BR: O Exterminador do Futuro
- The Godfather
  - pt-PT: O Padrinho
  - pt-BR: O Poderoso Chefão
- Harry Potter and the Chamber of Secrets
  - pt-PT: Harry Potter e a Câmara dos Segredos
  - pt-BR: Harry Potter e a Câmara Secreta
- Back to the Future
  - pt-PT: Regresso ao Futuro
  - pt-BR: De Volta para o Futuro
- Halloween
  - pt-PT: Halloween - O Regresso do Mal
  - pt-BR: Halloween - A Noite do Terror
- Zootopia
  - pt-PT: Zootropolis
  - pt-BR: Zootopia: Essa Cidade e o Bicho


This PR simply adds pt-BR as an option in the config page and creates an exception for pt-BR when sanitizing Jackett Indexers' language. Notice, TMDB API accepts both pt-br and pt-BR (Brazilian Portuguese is an officially supported language) but for Jackett country codes must be in capital letters.

Recently, a PR I submitted to Jackettio contributing with the same feature was accepted (https://github.com/arvida42/jackettio/pull/37)

Fun fact: The Brazilian population is larger and poorer than Portugal so they are more likely to use your add-on. In addition, Jackett has more pt-BR indexers (7 private indexers + 6 public indexers) than pt-PT (4 private indexers). Therefore, both Portugueses and Brazilians would benefit of such a feature.