### PR TITLE
Add checkbox that disables language filter and enables indexers oriented language setting

### DIFF
--- a/source/jackett/jackett_service.py
+++ b/source/jackett/jackett_service.py
@@ -26,7 +26,7 @@ class JackettService:
     def search(self, media):
         self.logger.info("Started Jackett search for " + media.type + " " + media.titles[0])
 
-        indexers = self.__get_indexers()
+        indexers = self.get_indexers()
         threads = []
         results_queue = queue.Queue()  # Create a Queue instance to hold the results
 
@@ -189,7 +189,7 @@ class JackettService:
 
         return results
 
-    def __get_indexers(self):
+    def get_indexers(self):
         url = f"{self.__base_url}/indexers/all/results/torznab/api?apikey={self.__api_key}&t=indexers&configured=true"
 
         try:

--- a/source/main.py
+++ b/source/main.py
@@ -129,6 +129,9 @@ async def get_results(config: str, stream_type: str, stream_id: str, request: Re
     logger.info(f"Getting media from {config['metadataProvider']}")
     if config['metadataProvider'] == "tmdb" and config['tmdbApi']:
         metadata_provider = TMDB(config)
+        if not COMMUNITY_VERSION and config['jackett']:
+            jackett_service = JackettService(config)
+            metadata_provider.indexers = jackett_service.get_indexers()
     else:
         metadata_provider = Cinemeta(config)
     media = metadata_provider.get_metadata(stream_id, stream_type)
@@ -158,7 +161,7 @@ async def get_results(config: str, stream_type: str, stream_id: str, request: Re
             logger.info("No cached results found")
 
         logger.info("Searching for results on Jackett")
-        jackett_service = JackettService(config)
+        jackett_service = jackett_service if jackett_service else JackettService(config)
         jackett_search_results = jackett_service.search(media)
         logger.info("Got " + str(len(jackett_search_results)) + " results from Jackett")
 

--- a/source/main.py
+++ b/source/main.py
@@ -126,14 +126,15 @@ async def get_results(config: str, stream_type: str, stream_id: str, request: Re
     config = parse_config(config)
     logger.info(stream_type + " request")
 
-    logger.info(f"Getting media from {config['metadataProvider']}")
     if config['metadataProvider'] == "tmdb" and config['tmdbApi']:
         metadata_provider = TMDB(config)
         if not COMMUNITY_VERSION and config['jackett']:
+            logger.info(f"Getting indexers' languages from Jackett for setting up TMDB")
             jackett_service = JackettService(config)
             metadata_provider.indexers = jackett_service.get_indexers()
     else:
         metadata_provider = Cinemeta(config)
+    logger.info(f"Getting media from {config['metadataProvider']}")
     media = metadata_provider.get_metadata(stream_id, stream_type)
     logger.info("Got media and properties: " + str(media.titles))
 

--- a/source/main.py
+++ b/source/main.py
@@ -180,7 +180,7 @@ async def get_results(config: str, stream_type: str, stream_id: str, request: Re
     torrent_smart_container = TorrentSmartContainer(torrent_results, media)
 
     if config['debrid']:
-        if config['service'] == "torbox":
+        if config['service'] in ["torbox", "premiumize"]:
             logger.debug("Checking availability")
             hashes = torrent_smart_container.get_hashes()
             ip = request.client.host

--- a/source/main.py
+++ b/source/main.py
@@ -120,6 +120,7 @@ logger.info("Started Jackett Addon")
 
 @app.get("/{config}/stream/{stream_type}/{stream_id}")
 async def get_results(config: str, stream_type: str, stream_id: str, request: Request):
+    jackett_service = None
     start = time.time()
     stream_id = stream_id.replace(".json", "")
 

--- a/source/metdata/tmdb.py
+++ b/source/metdata/tmdb.py
@@ -7,6 +7,10 @@ from models.series import Series
 from utils.logger import setup_logger
 
 class TMDB(MetadataProvider):
+    def __init__(self, config):
+        super().__init__(config)
+        self._indexers = None
+        
     @property
     def indexers(self):
         return self._indexers
@@ -20,19 +24,22 @@ class TMDB(MetadataProvider):
         full_id = id.split(":")
 
         result = None
-
-        for lang in self.config['languages']:
+        if self.config['getAllLanguages'] and self._indexers and len(self._indexers) > 0:
+          languages = list({indexer.language for indexer in self._indexers}) # Use set to remove duplicated languages
+        else:
+          languages = self.config['languages']
+        for lang in languages:
             url = f"https://api.themoviedb.org/3/find/{full_id[0]}?api_key={self.config['tmdbApi']}&external_source=imdb_id&language={lang}"
             response = requests.get(url)
             data = response.json()
 
-            if lang == self.config['languages'][0]:
+            if lang == languages[0]:
                 if type == "movie":
                     result = Movie(
                         id=id,
                         titles=[self.replace_weird_characters(data["movie_results"][0]["title"])],
                         year=data["movie_results"][0]["release_date"][:4],
-                        languages=self.config['languages']
+                        languages=languages
                     )
                 else:
                     result = Series(
@@ -40,7 +47,7 @@ class TMDB(MetadataProvider):
                         titles=[self.replace_weird_characters(data["tv_results"][0]["name"])],
                         season="S{:02d}".format(int(full_id[1])),
                         episode="E{:02d}".format(int(full_id[2])),
-                        languages=self.config['languages']
+                        languages=languages
                     )
             else:
                 if type == "movie":

--- a/source/metdata/tmdb.py
+++ b/source/metdata/tmdb.py
@@ -7,6 +7,13 @@ from models.series import Series
 from utils.logger import setup_logger
 
 class TMDB(MetadataProvider):
+    @property
+    def indexers(self):
+        return self._indexers
+    @indexers.setter
+    def indexers(self, indexers_):
+        self._indexers = indexers_
+    
     def get_metadata(self, id, type):
         self.logger.info("Getting metadata for " + type + " with id " + id)
 

--- a/source/templates/config.js
+++ b/source/templates/config.js
@@ -171,7 +171,7 @@ function getLink(method) {
         maxSize,
         exclusionKeywords,
         'languages': selectedLanguages,
-        'getAllLanguages': getAllLanguages,
+        getAllLanguages,
         'sort': filter,
         resultsPerQuality,
         maxResults,

--- a/source/templates/config.js
+++ b/source/templates/config.js
@@ -30,6 +30,11 @@ function updateProviderFields(isChangeEvent = false) {
     } else {
         setElementDisplay('tmdb-fields', 'none');
     }
+    if (!document.getElementById('get-all-languages')?.checked) {
+        setElementDisplay('languages-fields', 'block');
+    } else {
+        setElementDisplay('languages-fields', 'none');
+    }
     // if (!isChangeEvent) {
     //     if (document.getElementById('jackett-fields')) {
     //         document.getElementById('jackett-host').value = '';
@@ -85,6 +90,7 @@ function loadData() {
             }
         });
 
+        document.getElementById('get-all-languages').checked = data.getAllLanguages;
     }
 }
 
@@ -138,6 +144,8 @@ function getLink(method) {
         }
     });
 
+    const getAllLanguages = document.getElementById('get-all-languages').checked;
+
     let filter;
     sorts.forEach(sort => {
         if (document.getElementById(sort).checked) {
@@ -163,6 +171,7 @@ function getLink(method) {
         maxSize,
         exclusionKeywords,
         'languages': selectedLanguages,
+        'getAllLanguages': getAllLanguages,
         'sort': filter,
         resultsPerQuality,
         maxResults,

--- a/source/templates/index.html
+++ b/source/templates/index.html
@@ -375,7 +375,7 @@
                         <label for="language" class="block text-sm font-medium mb-2 dark:text-white">Language</label>
                         <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400">Choose your languages</p>
 
-                        <div class="multipleSelection mt-2">
+                        <div class="multipleSelection mt-2" id="languages-fields">
                             <div class="selectBox" onclick="showCheckboxes()">
                                 <select class="py-3 px-4 pe-9 block w-full border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-slate-900 dark:border-gray-700 dark:text-gray-400 dark:focus:ring-gray-600">
                                     <option>Languages</option>
@@ -439,6 +439,17 @@
                                     🌍 <span class="ml-1">MULTi</span>
                                 </label>
                             </div>
+                        </div>
+                    </div>
+                    <div class="mt-10 relative flex gap-x-3">
+                        <div class="flex h-6 items-center">
+                            <input id="get-all-languages" name="get-all-languages" value="" type="checkbox"
+                                   class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
+                                   oninput="updateProviderFields(true)">
+                        </div>
+                        <div class="text-sm leading-6">
+                            <label for="get-all-languages" class="block text-sm font-medium mb-2 dark:text-white">Get
+                                all languages</label>
                         </div>
                     </div>
                     <div class="mt-6 space-y-6">

--- a/source/utils/filter/language_filter.py
+++ b/source/utils/filter/language_filter.py
@@ -9,6 +9,11 @@ class LanguageFilter(BaseFilter):
         super().__init__(config)
 
     def filter(self, data):
+
+        if self.config['getAllLanguages']:
+            logger.info(f"Skipping language filtering because of 'getAllLanguages' setting.")
+            return data
+
         filtered_data = []
         for torrent in data:
             if len(torrent.languages) == 0:


### PR DESCRIPTION
This PR builds upon the original proposal in #166 to introduce a checkbox (getAllLanguages) that disables filtering by languages. It resolves issues identified in #176 by leveraging the language of Jackett's Indexers to request best TMDB metadata.

This approach ensures the feature is more flexible and powerful, while maintaining backward compatibility and user awareness of how language settings are applied.

Closes #166.
Addresses #176.