### PR TITLE
[FIX] regression for premiumize introduced in #158

### DIFF
--- a/source/main.py
+++ b/source/main.py
@@ -176,7 +176,7 @@ async def get_results(config: str, stream_type: str, stream_id: str, request: Re
     torrent_smart_container = TorrentSmartContainer(torrent_results, media)
 
     if config['debrid']:
-        if config['service'] == "torbox":
+        if config['service'] in ["torbox", "premiumize"]:
             logger.debug("Checking availability")
             hashes = torrent_smart_container.get_hashes()
             ip = request.client.host


### PR DESCRIPTION
The merge commit of #158 introduced a regression for premiumize users. Developer assumed only Torbox maintains cache API working. For that reason, all streams show incorrectly as not cached. The fix consists of adding an exception to premiumize alongside torbox for availability checking.

<img width="360" alt="image" src="https://github.com/user-attachments/assets/884f5c0a-88ba-45a7-9d48-feec463f0bbd">
