### PR TITLE
Harden parsed_data against Indexers' irregular attribute types

### DIFF
--- a/source/torrent/torrent_item.py
+++ b/source/torrent/torrent_item.py
@@ -30,6 +30,14 @@ class TorrentItem:
         self.availability = False  # If it's instantly available on the debrid service
 
         self.parsed_data = parsed_data  # Ranked result
+        if not self.parsed_data.quality:
+            self.parsed_data.quality = []
+        if isinstance(self.parsed_data.quality, str):
+            self.parsed_data.quality = [self.parsed_data.quality]
+        if not self.parsed_data.resolution:
+            self.parsed_data.resolution = []
+        if isinstance(self.parsed_data.resolution, str):
+            self.parsed_data.resolution = [self.parsed_data.resolution]
 
     def to_debrid_stream_query(self, media: Media) -> dict:
         return {


### PR DESCRIPTION
This add-on naively assumes the Jackett Indexers return well formatted data. Unfortunately, that is not always the case. Ironically, I found this issue by using this add-on with my own Indexers. Of course I will fix them but in the meantime I realized it is interesting to prevent stremio-jackett from breaking due to Jackett Indexers' mistakes.

The spots where I identified use of parsed_data attributes unsafely include:
https://github.com/aymene69/stremio-jackett/blob/main/source/utils/cache.py#L46-L47
https://github.com/aymene69/stremio-jackett/blob/main/source/utils/stremio_parser.py#L60-L62
https://github.com/aymene69/stremio-jackett/blob/main/source/utils/stremio_parser.py#L96-L99
https://github.com/aymene69/stremio-jackett/blob/main/source/utils/filter/quality_exclusion_filter.py#L21

Instead of checking for the attribute type in-place, I preferred handling anomalies once in the TorrentItem constructor.
