### PR TITLE
Pin dependencies, shrink container size by 1.4GB, Fix file selection

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.2
+FROM python:3.14.3-alpine3.22
 
 WORKDIR /app
 

--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.14.3-alpine3.22
 WORKDIR /app
 
 # This is to prevent Python from buffering stdout and stderr
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 COPY requirements.txt .
 

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,9 +1,9 @@
-fastapi
-uvicorn
-starlette
-requests
+fastapi==0.110.3
+uvicorn==0.30.6
+starlette==0.37.2
+requests==2.32.3
 bencode.py
-jinja2
-aiocron
-python-dotenv
+jinja2==3.1.4
+aiocron==1.8
+python-dotenv==1.0.1
 rank-torrent-name >= 1.0.0

--- a/source/utils/general.py
+++ b/source/utils/general.py
@@ -1,3 +1,5 @@
+import re
+
 from RTN import parse
 
 from utils.logger import setup_logger
@@ -11,11 +13,19 @@ video_formats = {".mkv", ".mp4", ".avi", ".mov", ".flv", ".wmv", ".webm", ".mpg"
                  ".svi", ".3gp", ".3g2", ".mxf", ".roq", ".nsv", ".flv", ".f4v", ".f4p", ".f4a", ".f4b"}
 
 
-def season_episode_in_filename(filename, season, episode):
+def season_episode_in_filename(filename, season, episode, strict=True):
     if not is_video_file(filename):
         return False
-    parsed_name = parse(filename)
-    return int(season.replace("S", "")) in parsed_name.seasons and int(episode.replace("E", "")) in parsed_name.episodes
+    if strict:
+        parsed_name = parse(filename)
+        return int(season.replace("S", "")) in parsed_name.seasons and int(episode.replace("E", "")) in parsed_name.episodes
+    else:
+        pattern = re.compile(
+            r'[Ss]0*' + str(int(season.replace("S", ""))) +
+            r'[Ee]0*' + str(int(episode.replace("E", ""))),
+            re.IGNORECASE
+        )
+        return bool(pattern.search(filename))
 
 
 def get_info_hash_from_magnet(magnet: str):


### PR DESCRIPTION
I was not able to build the container from main due to incompatible dependencies. Leaving dependencies unpinned is a bad pattern for this exact reason (and security concerns). 

This PR pins the dependencies to sane working versions. For dependency updates, I strongly recommend dependabot or a similar mechanism, so version compatibility can be tested on a branch first. 

I also changed the base image to python:3.14.3-alpine3.22, which drops the container size from 1.6GB to ~200MB. The only minor difference is that the alpine container has no timezone set, but it will automatically default to UTC if TZ is specified in the environment, thus matching the previous base image behavior.

Finally, I fixed #186 file selection not working (`ERROR - An error occurred: season_episode_in_filename() got an unexpected keyword argument 'strict'`)