### PR TITLE
fix: RTN API compatibility - handle both ParsedData and Torrent objects

### DIFF
--- a/source/utils/filter_results.py
+++ b/source/utils/filter_results.py
@@ -13,12 +13,13 @@ quality_order = {"4k": 0, "2160p": 0, "1080p": 1, "720p": 2, "480p": 3}
 
 
 def sort_quality(item):
-    if item.parsed_data.data.resolution == None:
+    parsed_data = item.parsed_data.data if hasattr(item.parsed_data, "data") else item.parsed_data
+    if parsed_data.resolution == None:
         return float('inf'), True
 
     # TODO: first resolution?
-    return quality_order.get(item.parsed_data.data.resolution,
-                             float('inf')), item.parsed_data.data.resolution is None
+    return quality_order.get(parsed_data.resolution,
+                             float('inf')), parsed_data.resolution is None
 
 
 def items_sort(items, config):

--- a/source/utils/stremio_parser.py
+++ b/source/utils/stremio_parser.py
@@ -54,7 +54,7 @@ def parse_to_debrid_stream(torrent_item: TorrentItem, configb64, host, torrentin
     else:
         name = f"{DOWNLOAD_REQUIRED}\n"
 
-    parsed_data = torrent_item.parsed_data.data
+    parsed_data = torrent_item.parsed_data.data if hasattr(torrent_item.parsed_data, "data") else torrent_item.parsed_data
 
     name += f"{parsed_data.resolution or 'Unknown'}" + (f" ({parsed_data.quality})" if parsed_data.quality else "")
 


### PR DESCRIPTION
## Problem

Recent versions of the `RTN` (rank-torrent-name) library changed its API:
- `parse()` now returns a `ParsedData` object directly (attributes on the object itself)
- `sort_torrents()` still returns `Torrent` objects (attributes under `.data`)

This causes `AttributeError` crashes in two places when `parsed_data` is a `ParsedData` instance instead of a `Torrent` instance:

1. `stremio_parser.py:57` — `torrent_item.parsed_data.data` fails with `AttributeError: 'ParsedData' object has no attribute 'data'`
2. `filter_results.py:16` — `item.parsed_data.data.resolution` fails with the same error

## Fix

Added `hasattr` checks to handle both object types gracefully:

```python
parsed_data = item.parsed_data.data if hasattr(item.parsed_data, "data") else item.parsed_data
```

This is backwards-compatible: if `.data` exists (old `Torrent` object), use it; otherwise use the object directly (`ParsedData`).

## Files changed
- `source/utils/stremio_parser.py` — line 57
- `source/utils/filter_results.py` — `sort_quality` function